### PR TITLE
fix: persist dark/light theme preference to localStorage

### DIFF
--- a/sentinel-frontend/app/layout.tsx
+++ b/sentinel-frontend/app/layout.tsx
@@ -1,9 +1,11 @@
+
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { GlobalShortcuts } from "@/components/common/GlobalShortcuts";
 import { ToastContainer } from "../components/notifications/Toast";
 import { WebSocketProvider } from "@/lib/WebSocketContext";
+import { STORAGE_KEY } from "@/hooks/useTheme";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -60,14 +62,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <script
           dangerouslySetInnerHTML={{
             __html: `
               (function() {
                 try {
-                  var stored = localStorage.getItem('sentinel-theme');
+                  var stored = localStorage.getItem('${STORAGE_KEY}');
                   var theme = (stored === 'dark' || stored === 'light')
                     ? stored
                     : (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');

--- a/sentinel-frontend/hooks/useTheme.ts
+++ b/sentinel-frontend/hooks/useTheme.ts
@@ -2,10 +2,10 @@ import { useState, useEffect } from 'react';
 
 type Theme = 'dark' | 'light';
 
-const STORAGE_KEY = 'sentinel-theme';
+export const STORAGE_KEY = 'sentinel-theme';
 
 export function useTheme() {
-    const [theme, setTheme] = useState<Theme>('dark');
+    const [theme, setTheme] = useState<Theme | null>(null);
 
     useEffect(() => {
         const stored = localStorage.getItem(STORAGE_KEY);
@@ -18,11 +18,11 @@ export function useTheme() {
     }, []);
 
     const toggleTheme = () => {
-        const newTheme: Theme = theme === 'dark' ? 'light' : 'dark';
+        const newTheme: Theme = (theme ?? 'dark') === 'dark' ? 'light' : 'dark';
         setTheme(newTheme);
         localStorage.setItem(STORAGE_KEY, newTheme);
         document.documentElement.classList.toggle('light', newTheme === 'light');
     };
 
-    return { theme, toggleTheme };
+    return { theme: theme ?? 'dark', toggleTheme, isThemeResolved: theme !== null };
 }


### PR DESCRIPTION
## 📋 Description

Persists the user's dark/light theme preference across page refreshes and browser sessions using localStorage. 
Previously, the theme would reset to dark mode on every page reload. 
Also adds a blocking inline script in layout.tsx to prevent flash of wrong theme  on initial load.


## 🔗 Related Issues

Closes #85 

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update

## 🧪 How Has This Been Tested?

- Toggled to light mode → refreshed page → theme persisted 
- Toggled to dark mode → refreshed page → theme persisted 
- Cleared localStorage → refreshed → correctly fell back to system preference 
- No SSR errors (window is not defined) 

### Test Configuration:
- OS: Windows
- Node.js version: Latest one
- Browser (if applicable):Chrome

## ✅ Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests passed locally with my changes
- [ ] Any dependent changes have been merged and published

## 📸 Screenshots (if applicable)

<img width="953" height="363" alt="image" src="https://github.com/user-attachments/assets/4a50d60c-1cec-4432-8deb-d049eefd02f5" />
Light theme according to my systems's (Windows) prefernce.
<img width="941" height="365" alt="image" src="https://github.com/user-attachments/assets/0a3997c5-090d-4977-9995-ded24b6b8991" />
light mode in dashboard
<img width="942" height="368" alt="image" src="https://github.com/user-attachments/assets/92c214be-6226-4f01-a233-cfe29cdd97ff" />
dark mode
<img width="946" height="348" alt="image" src="https://github.com/user-attachments/assets/0495fd7f-e090-4a9f-acab-4175ceec76a6" />
same theme even after refreshing.

## 📝 Additional Notes

If you like my change, please merge it under Apetre 3.0

---

**Thank you for contributing to Sentinel! 🚀**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Theme preferences are now reliably persisted and applied on page load, respecting the system color scheme if no preference is saved.
  * Reduced flash of incorrect theme during startup for a smoother, more consistent visual experience across sessions.
  * Theme toggle now reflects and maintains the resolved theme state immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->