### PR TITLE
Fixes MTTR Computed From Paginated Subset (Closes #126)

### DIFF
--- a/sentinel-frontend/app/dashboard/incidents/page.tsx
+++ b/sentinel-frontend/app/dashboard/incidents/page.tsx
@@ -52,13 +52,13 @@ function IncidentsContent() {
     const [page, setPage] = useState(Number(searchParams.get("page")) || 1);
     const [pageSize, setPageSize] = useState(Number(searchParams.get("pageSize")) || 10);
 
-    const { incidents, isLoading, totalCount, totalActive, totalCritical, allServices } = useIncidentHistory({
-            filters,
-            search,
-            sort: sortConfig,
-            page,
-            pageSize,
-        });
+    const { incidents, allFilteredIncidents, isLoading, totalCount, totalActive, totalCritical, allServices } = useIncidentHistory({
+        filters,
+        search,
+        sort: sortConfig,
+        page,
+        pageSize,
+    });
 
     // Sync URL with state
     useEffect(() => {
@@ -154,7 +154,7 @@ function IncidentsContent() {
                         </div>
                         <div className="text-2xl font-bold text-white truncate">
                             {(() => {
-                                const resolvedIncidents = incidents.filter(
+                                const resolvedIncidents = allFilteredIncidents.filter(
                                     (i) => i.status === "resolved" && i.duration !== "N/A"
                                 );
                                 if (resolvedIncidents.length === 0) return "—";

--- a/sentinel-frontend/hooks/useIncidentHistory.ts
+++ b/sentinel-frontend/hooks/useIncidentHistory.ts
@@ -26,6 +26,7 @@ interface UseIncidentHistoryProps {
 
 interface UseIncidentHistoryResult {
     incidents: Incident[];
+    allFilteredIncidents: Incident[];
     isLoading: boolean;
     totalCount: number;
     totalActive: number;
@@ -254,6 +255,7 @@ export function useIncidentHistory({
 
     return {
         incidents: paginatedIncidents,
+        allFilteredIncidents: sortedIncidents,
         isLoading,
         totalCount: sortedIncidents.length,
         totalActive,


### PR DESCRIPTION
Closes #126

Problem
The MTTR (Mean Time To Resolution) stat card on the Incidents page was computed from incidents — the paginated slice (e.g., 10 items on page 1). This caused the displayed MTTR value to change depending on which page the user was viewing, making the metric unreliable and misleading.

Root Cause
The 

useIncidentHistory
 hook internally computes the full filtered+sorted dataset (sortedIncidents) but only exposed the paginated slice as incidents. The MTTR calculation in 

page.tsx
 used this paginated subset:

tsx
// Before (buggy)
const resolvedIncidents = incidents.filter(  // ← paginated subset!
    (i) => i.status === "resolved" && i.duration !== "N/A"
);
Fix

sentinel-frontend/hooks/useIncidentHistory.ts
 — Exposed allFilteredIncidents (full sorted list) in the hook's return interface and return object

sentinel-frontend/app/dashboard/incidents/page.tsx
 — MTTR now computed from allFilteredIncidents instead of paginated incidents
tsx
// After (fixed)
const resolvedIncidents = allFilteredIncidents.filter(  // ← full dataset
    (i) => i.status === "resolved" && i.duration !== "N/A"
);
Verification
✅ npx next build — exit code 0
✅ MTTR value stays stable when navigating between pages
✅ Table rendering still uses paginated incidents — no change to table behavior
Checklist
 Targeted fix — no unrelated changes
 Build passes
 No breaking changes to existing hook consumers (additive field only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MTTR (Mean Time To Recovery) calculation to aggregate metrics from all filtered incidents instead of only the currently displayed paginated results, improving metric accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->